### PR TITLE
Update to UE4SS v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.4] - 2024-02-04
+
+- Updated to UE4SS v3.0.0
+
 ## [0.1.3] - 2024-02-01
 
 - Added Pak parser to better ascertain modTypes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "palworld",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Vortex Extension for Palworld",
   "author": "Nexus Mods",
   "private": true,

--- a/src/common.ts
+++ b/src/common.ts
@@ -28,7 +28,7 @@ export const IGNORE_CONFLICTS = ['ue4sslogicmod.info', '.ue4sslogicmod', '.logic
 export const UE4SS_ENABLED_FILE = 'enabled.txt';
 export const XBOX_UE4SS_XINPUT_REPLACEMENT = 'xinput1_4.dll';
 export const UE4SS_FILES = [
-  'xinput1_3.dll', 'UE4SS-settings.ini',
+  'dwmapi.dll', 'UE4SS-settings.ini',
 ];
 
 export const UE_PAK_TOOL_FILES = [
@@ -46,7 +46,7 @@ export const MOD_TYPE_UNREAL_PAK_TOOL = 'palworld-unreal-pak-tool-modtype';
 
 export type PakModType = 'palworld-pak-modtype' | 'palworld-blueprint-modtype';
 
-export const UE4SS_XINPUT_FILENAME = 'UE4SS_Xinput_v2.5.2.zip';
+export const UE4SS_XINPUT_FILENAME = 'UE4SS_v3.0.0.zip';
 export const UE_PAK_TOOL_FILENAME = 'UnrealPakTool.zip';
 
 export const PLUGIN_REQUIREMENTS: IPluginRequirement[] = [

--- a/src/common.ts
+++ b/src/common.ts
@@ -26,7 +26,6 @@ export const PAK_EXTENSIONS = ['.pak', '.utoc', '.ucas'];
 export const IGNORE_CONFLICTS = ['ue4sslogicmod.info', '.ue4sslogicmod', '.logicmod'];
 
 export const UE4SS_ENABLED_FILE = 'enabled.txt';
-export const XBOX_UE4SS_XINPUT_REPLACEMENT = 'xinput1_4.dll';
 export const UE4SS_FILES = [
   'dwmapi.dll', 'UE4SS-settings.ini',
 ];

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -2,7 +2,7 @@
 import { fs, selectors, types } from 'vortex-api';
 import path from 'path';
 
-import { GAME_ID, UE4SS_FILES, UE4SS_PATH_PREFIX, XBOX_UE4SS_XINPUT_REPLACEMENT } from './common';
+import { GAME_ID, UE4SS_FILES, UE4SS_PATH_PREFIX } from './common';
 
 //#region UE4SS Installer and test.
 export async function testUE4SSInjector(files: string[], gameId: string): Promise<types.ISupportedResult> {
@@ -21,11 +21,8 @@ export async function installUE4SSInjector(api: types.IExtensionApi, files: stri
     const accum = await accumP;
     const segments = iter.split(path.sep);
     if (path.extname(segments[segments.length - 1]) !== '') {
-      // Apparently xinput1_3 isn't being loaded by the xbox gamepass version.
-      //  we rename the file to xinput1_4
-      const destination = gameStore === 'xbox' && iter === UE4SS_FILES[0]
-        ? path.join(targetPath, XBOX_UE4SS_XINPUT_REPLACEMENT)
-        : path.join(targetPath, iter);
+      // UE4SS 3.0.0 uses dwmapi.dll instead of xinput1_3.dll or xinput1_4.dll
+      const destination = path.join(targetPath, iter);
 
       if (iter === UE4SS_FILES[1]) {
         // Disable the use of Unreal's object array cache regardless of game store - it's causing crashes.


### PR DESCRIPTION
This MR fixes new installs, since currently new users cannot install the extension. UE4SS updated to 3.0.0 today, and the download for 2.5.2 is no longer working.

I wasn't able to find a clean way to upgrade the "UE4 Scripting System" mod.
Currently, you can manually remove "UE4 Scripting System" and check "Delete archive" and it will download the new one.

Feel free to use this as a start, if it helps.