### PR TITLE
Fixes for unrealpak buffer size, path whitespace and decimal points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.7] - 2024-02-20
+
+- If PAK reading fails due to max buffer exceeded, it is retried with a larger buffer 
+- Fix for false error when installing mods with a decimal point in the name  
+- Fix for UnrealPak not being found when staging folder has whitespace in it's path  
+
 ## [0.1.6] - 2024-02-19
 
 - Fixed mods.txt file addition/removal error notifications being suppressed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "palworld",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Vortex Extension for Palworld",
   "author": "Nexus Mods",
   "private": true,

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -100,8 +100,8 @@ export async function installLuaMod(api: types.IExtensionApi, files: string[], d
     value: folderId,
   }
   const instructions = files.reduce((accum, iter) => {
-    if (path.extname(iter) === '') {
-      // Get rid of directories
+    if (iter.endsWith(path.sep) || path.extname(iter) === '') {
+      // No directories
       return accum;
     }
     const fileSegments = iter.split(path.sep);
@@ -149,7 +149,7 @@ export async function installRootMod(api: types.IExtensionApi, files: string[], 
   };
   // I guess that if we're hear - that means that we can just copy the files over?
   const instructions = files.reduce((accum, iter) => {
-    if (path.extname(iter) === '') {
+    if (iter.endsWith(path.sep) || path.extname(iter) === '') {
       // No directories
       return accum;
     }

--- a/src/modTypes.ts
+++ b/src/modTypes.ts
@@ -43,6 +43,7 @@ export async function testPakPath(api: types.IExtensionApi, instructions: types.
   if (hasModTypeInstruction(instructions)) {
     return Promise.resolve(false);
   }
+  /*
   try {
     const modType = await runPakTool(api, instructions);
     if (modType && modType === MOD_TYPE_PAK) {
@@ -51,7 +52,7 @@ export async function testPakPath(api: types.IExtensionApi, instructions: types.
   } catch (err) {
     // Pak tool fudged up - resume default stop pattern installation.
     log('error', 'Failed to ascertain modType using pak tool', err);
-  }
+  }*/
   const filteredPaks = instructions
     .filter((inst: types.IInstruction) => (inst.type === 'copy')
       && (PAK_EXTENSIONS.includes(path.extname(inst.source as any))));

--- a/src/util.ts
+++ b/src/util.ts
@@ -151,3 +151,15 @@ export function dismissNotifications(api: types.IExtensionApi) {
   // We're not dismissing the downloader notifications intentionally.
   [NOTIF_ID_BP_MODLOADER_DISABLED, NOTIF_ID_UE4SS_UPDATE].forEach(id => api.dismissNotification(id));
 }
+
+export function formatBytes(bytes, decimals = 2) {
+  if (!+bytes) return '0 Bytes'
+
+  const k = 1024
+  const dm = decimals < 0 ? 0 : decimals
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`
+}


### PR DESCRIPTION
PAK reading fails due to max buffer exceeded, it is retried with a larger buffer 
Fix for false error when installing mods with a decimal point in the name  
Fix for UnrealPak not being found when staging folder has whitespace in it's path 