### PR TITLE
Added support for UE4SS's new archive structure

### DIFF
--- a/generateMemberVariableLayout.js
+++ b/generateMemberVariableLayout.js
@@ -1,0 +1,73 @@
+/* eslint-disable */
+import https from 'https';
+import fs from 'fs';
+import path from 'path';
+import ini from 'ini';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const url = 'https://raw.githubusercontent.com/UE4SS-RE/RE-UE4SS/main/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_01_Template.ini';
+const outputPath = path.join(__dirname, 'src', 'assets', 'MemberVariableLayout_5_01_Template.ini');
+if (fs.existsSync(outputPath)) {
+  console.log('File already exists. Skipping download.');
+} else {
+  https.get(url, (response) => {
+    if (response.statusCode === 200) {
+      const file = fs.createWriteStream(outputPath);
+      response.pipe(file);
+      file.on('finish', () => {
+        file.close();
+        console.log('Download completed.');
+      });
+    } else {
+      console.log(`Failed to download file: ${response.statusCode}`);
+    }
+  }).on('error', (err) => {
+    console.error(`Error: ${err.message}`);
+  });
+}
+
+fs.readFile(outputPath, 'utf-8', (err, data) => {
+  if (err) {
+    console.error(`Error reading file: ${err.message}`);
+    return;
+  }
+
+  const config = ini.parse(data);
+  const uEnumSection = {
+    CppForm: '0x58',
+    CppType: '0x30',
+    EnumDisplayNameFn: '0x60',
+    EnumFlags_Internal: '0x5C',
+    EnumPackage: '0x68',
+    Names: '0x48'
+  };
+
+  let needsUpdate = false;
+  if (!config.UEnum) {
+    config.UEnum = uEnumSection;
+    needsUpdate = true;
+  } else {
+    for (const key in uEnumSection) {
+      if (config.UEnum[key] !== uEnumSection[key]) {
+        config.UEnum[key] = uEnumSection[key];
+        needsUpdate = true;
+      }
+    }
+  }
+
+  if (needsUpdate) {
+    const newOutputPath = path.join(__dirname, 'src', 'assets', 'MemberVariableLayout.ini');
+    fs.writeFile(newOutputPath, ini.stringify(config), (err) => {
+      if (err) {
+        console.error(`Error writing file: ${err.message}`);
+      } else {
+        console.log('File updated and saved as MemberVariableLayout.ini');
+      }
+    });
+  } else {
+    console.log('No updates needed.');
+  }
+});

--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "copyassets": "copyfiles -f ./src/assets/** ./dist/",
-    "build": "npx webpack && yarn copyassets && node createinfojson.js && yarn packplugin && yarn copystyles",
+    "build": "npx webpack && yarn generatemembervariablelayout && yarn copyassets && node createinfojson.js && yarn packplugin && yarn copystyles",
     "buildcopydev": "yarn build && yarn copyplugindev",
     "copystyles": "node copystyles.js",
     "copyplugin": "node copyplugin.js",
     "copyplugindev": "node copyplugin.js -dev",
-    "packplugin": "node packageplugin.js"
+    "packplugin": "node packageplugin.js",
+    "generatemembervariablelayout": "node generatemembervariablelayout.js"
   },
   "license": "GPLV3",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "palworld",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Vortex Extension for Palworld",
   "author": "Nexus Mods",
   "private": true,

--- a/src/common.ts
+++ b/src/common.ts
@@ -56,7 +56,6 @@ export type PakModType = 'palworld-pak-modtype' | 'palworld-blueprint-modtype';
 
 export const UE4SS_XINPUT_FILENAME = 'UE4SS_v3.0.0.zip';
 export const UE_PAK_TOOL_FILENAME = 'UnrealPakTool.zip';
-
 export const PLUGIN_REQUIREMENTS: IPluginRequirement[] = [
   {
     archiveFileName: UE4SS_XINPUT_FILENAME,
@@ -66,7 +65,7 @@ export const PLUGIN_REQUIREMENTS: IPluginRequirement[] = [
     githubUrl: 'https://api.github.com/repos/UE4SS-RE/RE-UE4SS',
     findMod: (api: types.IExtensionApi) => findModByFile(api, '', UE4SS_SETTINGS_FILE),
     findDownloadId: (api: types.IExtensionApi) => findDownloadIdByPattern(api, PLUGIN_REQUIREMENTS[0]),
-    fileArchivePattern: new RegExp(/^UE4SS.*v(\d+\.\d+\.\d+)/, 'i'),
+    fileArchivePattern: new RegExp(/^UE4SS.*v(\d+\.\d+\.\d+(-\w+(\.\d+)?)?)/, 'i'),
     resolveVersion: (api: types.IExtensionApi) => resolveVersionByPattern(api, PLUGIN_REQUIREMENTS[0]),
   },
   {

--- a/src/common.ts
+++ b/src/common.ts
@@ -34,6 +34,7 @@ export const IGNORE_DEPLOY = [MODS_FILE, MODS_FILE_BACKUP, UE4SS_ENABLED_FILE];
 
 export const UE4SS_DWMAPI = 'dwmapi.dll';
 export const XBOX_UE4SS_XINPUT_REPLACEMENT = 'xinput1_4.dll';
+export const UE4SS_MEMBER_VARIABLE_LAYOUT_FILE = 'MemberVariableLayout.ini';
 export const UE4SS_SETTINGS_FILE = 'UE4SS-settings.ini';
 export const UE4SS_2_5_2_FILES = ['xinput1_3.dll', UE4SS_SETTINGS_FILE];
 export const UE4SS_3_0_0_FILES = [UE4SS_DWMAPI, UE4SS_SETTINGS_FILE];

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,9 +215,11 @@ async function setup(api: types.IExtensionApi, discovery: types.IDiscoveryResult
   const ensurePath = (filePath: string) => fs.ensureDirWritableAsync(path.join(discovery.path, filePath));
   try {
     const UE4SSPath = resolveUE4SSPath(api);
-    await ensurePath(path.join(UE4SSPath, 'Mods'));
-    await ensurePath(PAK_MODSFOLDER_PATH);
-    await ensurePath(BPPAK_MODSFOLDER_PATH);
+    const oldSegments = UE4SSPath.split(path.sep);
+    oldSegments.pop();
+    oldSegments.push('Mods');
+    const oldScriptSystemPath = oldSegments.join(path.sep);
+    await Promise.all([path.join(UE4SSPath, 'Mods'), oldScriptSystemPath, PAK_MODSFOLDER_PATH, BPPAK_MODSFOLDER_PATH].map(ensurePath));
     await migrate(api);
     await download(api, PLUGIN_REQUIREMENTS);
   } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {
   getLUAPath, testLUAPath, getLUAPathV2, testLUAPathV2,
 } from './modTypes';
 import { installLuaMod, installRootMod, installUE4SSInjector, testLuaMod, testRootMod, testUE4SSInjector } from './installers';
-import { testBluePrintModManager, testUE4SSVersion } from './tests';
+import { testBluePrintModManager, testMemberVariableLayout, testUE4SSVersion } from './tests';
 
 import { migrate } from './migrations';
 
@@ -272,6 +272,7 @@ async function onGameModeActivated(api: types.IExtensionApi) {
   try {
     await testUE4SSVersion(api);
     await testBluePrintModManager(api, 'gamemode-activated');
+    await testMemberVariableLayout(api, 'gamemode-activated');
   } catch (err) {
     // All errors should've been handled in the test - if this
     //  notification is reported - please fix the test.
@@ -290,6 +291,7 @@ async function onDidDeployEvent(api: types.IExtensionApi, profileId: string, dep
 
   try {
     await testBluePrintModManager(api, 'did-deploy');
+    await testMemberVariableLayout(api, 'did-deploy');
     await onDidDeployLuaEvent(api, profile);
   } catch (err) {
     log('warn', 'failed to test BluePrint Mod Manager', err);

--- a/src/modTypes.ts
+++ b/src/modTypes.ts
@@ -103,7 +103,10 @@ export function getLUAPath(api: types.IExtensionApi, game: types.IGame) {
     return '.';
   }
   const ue4ssPath = resolveUE4SSPath(api);
-  const luaPath = path.join(discovery.path, ue4ssPath, 'Mods');
+  const segments = ue4ssPath.split(path.sep);
+  segments.pop();
+  segments.push('Mods');
+  const luaPath = path.join(discovery.path, segments.join(path.sep));
   return luaPath;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface IGitHubRelease {
   tag_name: string;
   name: string;
   assets: IGitHubAsset[];
+  prerelease: boolean;
 }
 
 export interface IGitHubAsset {


### PR DESCRIPTION
part of nexus-mods/game-palworld#13

Testing should revolve around "migration".

Main use case to test:
1. Have an older version of the extension with the UE4SS and unrealpak parser mods installed.
2. Update the extension
3. Vortex should inform the user that there is a new version of UE4SS
4. Click download/install and ensure that the experimental build of UE4SS is installed and enabled.

Notes:
- All existing LUA mods will be moved to the new location.
- The build scripts have been modified to pull the MemberVariableLayout template from the UE4SS repo during packaging and add/modify the UEnum section keys as specified in https://github.com/UE4SS-RE/RE-UE4SS/issues/802
Special thanks to @Okaetsu and @UE4SS for keeping us updated.

~Newly installed LUA mods will be placed inside `./ue4ss/Mods`, any lua mods that have been installed prior to the extension update will still deploy to `./Mods` - users will have to manually switch to the new modType - this is intentional as UE4SS provides backwards compatibility for the old mods location.~